### PR TITLE
fix libelektra 0.9.5 API compatibility (thanks to @kodebach), update CI to Ubuntu Focal and use new APT repo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,6 @@ before_install:
   - sudo apt-key adv --keyserver keys.gnupg.net --recv-keys F26BBE02F3C315A19BF1F791A9A25CC1CC83E839
   - echo "deb https://debs.libelektra.org/focal focal main" >> /etc/apt/sources.list
   - sudo apt-get update
-  - sudo apt-get install libelektra5-all
+  - sudo apt-get install libelektra5-all libelektra-dev
 install:
   - go get -v ./...

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,13 @@
-dist: bionic
+dist: focal
 
 language: go
 go: "1.14"
 env:
   - GO111MODULE=on
 before_install:
-  - sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys D919CE8B27A64C16656FCA9FF1532673651F9C6C
-  - echo "deb https://ubuntu-bionic-repo.libelektra.org/ bionic main" >> /etc/apt/sources.list
+  - sudo apt-key adv --keyserver keys.gnupg.net --recv-keys F26BBE02F3C315A19BF1F791A9A25CC1CC83E839
+  - echo "deb https://debs.libelektra.org/focal focal main" >> /etc/apt/sources.list
   - sudo apt-get update
-  - sudo apt-get install libelektra4 libelektra-dev
+  - sudo apt-get install libelektra5-all
 install:
   - go get -v ./...

--- a/kdb/kdb.go
+++ b/kdb/kdb.go
@@ -37,7 +37,28 @@ func (e *KdbC) Open() error {
 		return err
 	}
 
-	handle := C.kdbOpen(key.Ptr)
+	handle := C.kdbOpen(nil, key.Ptr)
+
+	if handle == nil {
+		return errFromKey(key)
+	}
+
+	e.handle = handle
+
+	return nil
+}
+
+// Open creates a handle to the kdb library,
+// this is mandatory to Get / Set Keys.
+// This function also enforces a contract.
+func (e *KdbC) OpenWithContract(contract KeySet) error {
+	key, err := newKey("/")
+
+	if err != nil {
+		return err
+	}
+
+	handle := C.kdbOpen(contract.Ptr, key.Ptr)
 
 	if handle == nil {
 		return errFromKey(key)

--- a/kdb/kdb.go
+++ b/kdb/kdb.go
@@ -58,7 +58,9 @@ func (e *KdbC) OpenWithContract(contract KeySet) error {
 		return err
 	}
 
-	handle := C.kdbOpen(contract.Ptr, key.Ptr)
+	cContract, err := toCKeySet(contract)
+
+	handle := C.kdbOpen(cContract.Ptr, key.Ptr)
 
 	if handle == nil {
 		return errFromKey(key)

--- a/kdb/kdb_test.go
+++ b/kdb/kdb_test.go
@@ -26,12 +26,13 @@ func TestSet(t *testing.T) {
 	Checkf(t, err, "kdb.Open() failed: %v", err)
 
 	ks := elektra.NewKeySet()
-	key, _ := elektra.NewKey("user:/tests/go/elektra/set")
-	_, _ = kdb.Get(ks, key)
+	parentKey, _ := elektra.NewKey("user:/tests/go/elektra/set")
+	_, _ = kdb.Get(ks, parentKey)
 
+	key, _ := elektra.NewKey("user:/tests/go/elektra/set/key")
 	ks.AppendKey(key)
 
-	_, err = kdb.Set(ks, key)
+	_, err = kdb.Set(ks, parentKey)
 	Checkf(t, err, "kdb Set failed %v", err)
 }
 

--- a/kdb/key.go
+++ b/kdb/key.go
@@ -317,7 +317,7 @@ func (k *CKey) MetaMap() map[string]string {
 
 // Duplicate duplicates a Key.
 func (k *CKey) Duplicate(flags KeyCopyFlags) Key {
-	return wrapKey(C.keyDup(k.Ptr, flags))
+	return wrapKey(C.keyDup(k.Ptr, C.uint(flags)))
 }
 
 // IsBelow checks if this key is below the `other` key.

--- a/kdb/key.go
+++ b/kdb/key.go
@@ -19,24 +19,34 @@ import (
 	"unsafe"
 )
 
-type ElektraNamepace byte
+type ElektraNamespace byte
 
 const (
-	KEY_NS_NONE      ElektraNamepace = C.KEY_NS_NONE
-	KEY_NS_CASCADING ElektraNamepace = C.KEY_NS_CASCADING
-	KEY_NS_META      ElektraNamepace = C.KEY_NS_META
-	KEY_NS_SPEC      ElektraNamepace = C.KEY_NS_SPEC
-	KEY_NS_PROC      ElektraNamepace = C.KEY_NS_PROC
-	KEY_NS_DIR       ElektraNamepace = C.KEY_NS_DIR
-	KEY_NS_USER      ElektraNamepace = C.KEY_NS_USER
-	KEY_NS_SYSTEM    ElektraNamepace = C.KEY_NS_SYSTEM
-	KEY_NS_DEFAULT   ElektraNamepace = C.KEY_NS_DEFAULT
+	KEY_NS_NONE      ElektraNamespace = C.KEY_NS_NONE
+	KEY_NS_CASCADING ElektraNamespace = C.KEY_NS_CASCADING
+	KEY_NS_META      ElektraNamespace = C.KEY_NS_META
+	KEY_NS_SPEC      ElektraNamespace = C.KEY_NS_SPEC
+	KEY_NS_PROC      ElektraNamespace = C.KEY_NS_PROC
+	KEY_NS_DIR       ElektraNamespace = C.KEY_NS_DIR
+	KEY_NS_USER      ElektraNamespace = C.KEY_NS_USER
+	KEY_NS_SYSTEM    ElektraNamespace = C.KEY_NS_SYSTEM
+	KEY_NS_DEFAULT   ElektraNamespace = C.KEY_NS_DEFAULT
+)
+
+type KeyCopyFlags byte
+
+const (
+	KEY_CP_NAME   KeyCopyFlags = C.KEY_CP_NAME
+	KEY_CP_VALUE  KeyCopyFlags = C.KEY_CP_VALUE
+	KEY_CP_STRING KeyCopyFlags = C.KEY_CP_STRING
+	KEY_CP_META   KeyCopyFlags = C.KEY_CP_META
+	KEY_CP_ALL    KeyCopyFlags = C.KEY_CP_ALL
 )
 
 // Key is the wrapper around the Elektra Key.
 type Key interface {
 	Name() string
-	Namespace() ElektraNamepace
+	Namespace() ElektraNamespace
 	BaseName() string
 
 	String() string
@@ -55,7 +65,7 @@ type Key interface {
 	IsDirectlyBelow(key Key) bool
 	Compare(key Key) int
 
-	Duplicate() Key
+	Duplicate(flags KeyCopyFlags) Key
 
 	SetMeta(name, value string) error
 	SetName(name string) error
@@ -279,7 +289,7 @@ func (k *CKey) NextMeta() Key {
 
 // MetaSlice builds a slice of all meta Keys.
 func (k *CKey) MetaSlice() []Key {
-	dup := k.Duplicate().(*CKey)
+	dup := k.Duplicate(KEY_CP_ALL).(*CKey)
 	C.keyRewindMeta(dup.Ptr)
 
 	var metaKeys []Key
@@ -293,7 +303,7 @@ func (k *CKey) MetaSlice() []Key {
 
 // MetaMap builds a Key/Value map of all meta Keys.
 func (k *CKey) MetaMap() map[string]string {
-	dup := k.Duplicate().(*CKey)
+	dup := k.Duplicate(KEY_CP_ALL).(*CKey)
 	C.keyRewindMeta(dup.Ptr)
 
 	m := make(map[string]string)
@@ -306,8 +316,8 @@ func (k *CKey) MetaMap() map[string]string {
 }
 
 // Duplicate duplicates a Key.
-func (k *CKey) Duplicate() Key {
-	return wrapKey(C.keyDup(k.Ptr))
+func (k *CKey) Duplicate(flags KeyCopyFlags) Key {
+	return wrapKey(C.keyDup(k.Ptr, flags))
 }
 
 // IsBelow checks if this key is below the `other` key.
@@ -360,8 +370,8 @@ func (k *CKey) Compare(other Key) int {
 }
 
 // Namespace returns the namespace of a Key.
-func (k *CKey) Namespace() ElektraNamepace {
-	return ElektraNamepace(C.keyGetNamespace(k.Ptr))
+func (k *CKey) Namespace() ElektraNamespace {
+	return ElektraNamespace(C.keyGetNamespace(k.Ptr))
 }
 
 func nameWithoutNamespace(key Key) string {

--- a/kdb/key.go
+++ b/kdb/key.go
@@ -19,7 +19,7 @@ import (
 	"unsafe"
 )
 
-type ElektraNamespace byte
+type ElektraNamespace uint
 
 const (
 	KEY_NS_NONE      ElektraNamespace = C.KEY_NS_NONE
@@ -33,7 +33,7 @@ const (
 	KEY_NS_DEFAULT   ElektraNamespace = C.KEY_NS_DEFAULT
 )
 
-type KeyCopyFlags byte
+type KeyCopyFlags uint
 
 const (
 	KEY_CP_NAME   KeyCopyFlags = C.KEY_CP_NAME


### PR DESCRIPTION
The go-elekra **CI** is currently stuck with libelektra4 (0.9.3) packages from our outdated repo, but the bindings do not work with the current Elektra release.

This PR replaces the packages with the current libelektra5 (0.9.5) packages and uses Ubuntu Focal. This includes breaking API changes.

This PR includes #12 as well to fix the breaking API changes. Thanks to @kodebach!